### PR TITLE
chore: Update Cargo.lock for version 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-notifications"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "color-backtrace",


### PR DESCRIPTION
## Summary

- Updates Cargo.lock to match version 0.2.3 in Cargo.toml
- Fixes Nix build failure: `the lock file needs to be updated but --locked was passed`

## Test plan

- [ ] Nix build completes successfully with `nix build`

🤖 Generated with [Claude Code](https://claude.ai/code)