### PR TITLE
chore: Remove redundant test import in notification_image.rs

### DIFF
--- a/cosmic-notifications-util/src/notification_image.rs
+++ b/cosmic-notifications-util/src/notification_image.rs
@@ -10,9 +10,6 @@
 use fast_image_resize as fr;
 use image::ImageError;
 
-#[cfg(test)]
-use image::RgbaImage;
-
 /// Maximum width for notification images in pixels
 pub const MAX_IMAGE_WIDTH: u32 = 128;
 


### PR DESCRIPTION
## Summary

Removes a redundant `#[cfg(test)] use image::RgbaImage` import at module level in `notification_image.rs`. The test module already imports it locally at line 219.

## Result

- **Before:** 1 warning during `cargo check --tests`
- **After:** 0 warnings across entire workspace (lib + tests)
- **Tests:** All 269 pass

🤖 Generated with [Claude Code](https://claude.ai/code)