### PR TITLE
chore: Bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-notifications"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "color-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmic-notifications"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ashley Wulber <ashley@system76.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cosmic Notifications NG
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](https://github.com/olafkfreund/cosmic-notifications-ng/releases/tag/v0.3.0)
+[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](https://github.com/olafkfreund/cosmic-notifications-ng/releases/tag/v0.3.1)
 [![License](https://img.shields.io/badge/license-GPL--3.0-green.svg)](LICENSE)
 
 Enhanced Layer Shell notifications daemon for the COSMIC desktop environment, featuring **rich notification support** including images, action buttons, progress indicators, clickable URLs, animated content, **per-app notification rules**, and **notification grouping**.


### PR DESCRIPTION
## Summary
- Bump version from 0.3.0 to 0.3.1 in Cargo.toml
- Update Cargo.lock
- Update version badge in README.md
- Nix build correctly picks up new version (cosmic-notifications-0.3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)