### PR TITLE
fix: Filter out bare URL schemes from Chrome notifications

### DIFF
--- a/cosmic-ext-notifications-util/src/lib.rs
+++ b/cosmic-ext-notifications-util/src/lib.rs
@@ -37,7 +37,7 @@ pub use link::NotificationLink;
 pub use link_detector::{detect_links, is_safe_url, open_link};
 pub use markup_parser::{parse_markup, segments_to_plain_text, StyledSegment, TextStyle};
 pub use rich_content::RichContent;
-pub use sanitizer::{extract_hrefs, has_rich_content, sanitize_html, strip_html};
+pub use sanitizer::{clean_bare_schemes, extract_hrefs, has_rich_content, sanitize_html, strip_html};
 pub use urgency::NotificationUrgency;
 pub use urgency_style::{
     categories, category_icon, is_message_category, is_system_category, urgency_color,

--- a/src/app.rs
+++ b/src/app.rs
@@ -48,7 +48,7 @@ use cosmic::{Application, Element, app::Task};
 use cosmic_ext_notifications_config::NotificationsConfig;
 use cosmic_ext_notifications_util::{
     ActionId, CloseReason, Notification, NotificationLink,
-    detect_links, extract_hrefs, sanitize_html, strip_html,
+    clean_bare_schemes, detect_links, extract_hrefs, sanitize_html, strip_html,
 };
 
 use crate::state::NotificationState;
@@ -201,7 +201,8 @@ impl CosmicNotifications {
         let has_markup = cosmic_ext_notifications_util::has_rich_content(&body_text);
 
         // Strip HTML for link detection and plain text fallback
-        let display_body_str = strip_html(&sanitize_html(&body_text));
+        // Also clean bare URL schemes (e.g., "https://") that Chrome includes as truncated URLs
+        let display_body_str = clean_bare_schemes(&strip_html(&sanitize_html(&body_text)));
 
         // Detect plain text URLs in the stripped body
         let plain_links = detect_links(&display_body_str);


### PR DESCRIPTION
## Summary

- Chrome sends YouTube notifications with truncated anchor tags like `<a href="https://">https://</a>` where the URL is just the scheme with no host
- `is_safe_url()` only checked the scheme prefix but not that the URL had actual content after it, so `https://` alone was accepted and displayed as a "🔗 https://" link button
- Added `clean_bare_schemes()` to strip bare scheme lines from notification body display text

## Test plan

- [x] All 206 unit tests pass
- [x] `cargo check` succeeds
- [ ] Verify Chrome YouTube notifications no longer show "🔗 https://" link button
- [ ] Verify legitimate URLs still render correctly as link buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)