### PR TITLE
fix: Add cosmic-notifications symlink for COSMIC desktop compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
           '';
           installPhase = ''
             just prefix=$out install
+            ln -s cosmic-ext-notifications $out/bin/cosmic-notifications
           '';
         });
 


### PR DESCRIPTION
## Summary
- Add `cosmic-notifications` symlink in the Nix package install phase pointing to `cosmic-ext-notifications`
- COSMIC desktop expects the binary name `cosmic-notifications`, but the package was renamed to `cosmic-ext-notifications` for trademark compliance

## Test plan
- [x] `nix build` succeeds
- [x] `result/bin/cosmic-notifications` symlink exists and points to `cosmic-ext-notifications`
- [ ] Verify COSMIC desktop finds and launches the daemon correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)