### PR TITLE
chore: Update flake inputs and fix lint warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1769737823,
-        "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1769966877,
-        "narHash": "sha256-saM3CldynDtMFHRc25UdQ7EQtP5o+oSUgsHTMvIzzXw=",
+        "lastModified": 1773299640,
+        "narHash": "sha256-kTsZ5xGZqaeJ8jWsfZNACo/VsW3riVuIQEPWVGiqWKM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8a42e00e442d416e6c838fc6b40240da65aacbcd",
+        "rev": "8ac78ff968869cd05d9cb42fbf63bdbc6851ec19",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769740369,
-        "narHash": "sha256-xKPyJoMoXfXpDM5DFDZDsi9PHArf2k5BJjvReYXoFpM=",
+        "lastModified": 1773201692,
+        "narHash": "sha256-NXrKzNMniu4Oam2kAFvqJ3GB2kAvlAFIriTAheaY8hw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6308c3b21396534d8aaeac46179c14c439a89b8a",
+        "rev": "b6067cc0127d4db9c26c79e4de0513e58d0c40c9",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769857242,
-        "narHash": "sha256-3eKpRRzKz0KzY7CJzRXFm4POwEqbuTohyQ2ajI/zKvg=",
+        "lastModified": 1773194001,
+        "narHash": "sha256-50PPXBtH2xfKuNfQfUNOyuIFgZPEz5QVertQWS2MQJE=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "17304e9c7e11d26139672d3d77aa498b1cae0d69",
+        "rev": "8ed3cca4d30610fd0d3c1179c85418de2dc0a7c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,17 +5,14 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-filter, crane, fenix }:
+  outputs = { self, nixpkgs, flake-utils, nix-filter, crane, ... }:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
     in
@@ -50,7 +47,6 @@
             lld
             desktop-file-utils
             stdenv.cc.cc.lib
-            desktop-file-utils
             # Audio support for notification sounds
             alsa-lib
            ];
@@ -68,7 +64,7 @@
           inherit cosmic-ext-notifications-daemon;
         };
 
-        packages.default = cosmic-ext-notifications-daemon.overrideAttrs (oldAttrs: rec {
+        packages.default = cosmic-ext-notifications-daemon.overrideAttrs (_oldAttrs: {
           buildPhase= ''
             just prefix=$out build-release
           '';


### PR DESCRIPTION
## Summary
- Update nixpkgs, crane, fenix, and rust-analyzer flake inputs to latest (Mar 2026)
- Remove invalid `crane.inputs.nixpkgs.follows` (crane no longer has a nixpkgs input)
- Remove duplicate `desktop-file-utils` in buildInputs
- Fix unused `rec` and unused binding warnings in flake.nix

## Notes
COSMIC git dependencies (libcosmic, cosmic-time, cosmic-panel) were investigated but NOT updated — latest libcosmic HEAD breaks cosmic-time due to iced widget API changes. Current lockfile represents the most recent compatible set.

## Test plan
- [x] `nix build` succeeds
- [x] `nix flake check` passes
- [x] Binary output verified in `result/bin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)